### PR TITLE
Translate README to Japanese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,37 @@
 # React + TypeScript + Vite
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+このリポジトリは、React と TypeScript を Vite 上で動かすための最小テンプレートです。HMR (Hot Module Replacement) が有効になっており、基本的な ESLint 設定も含まれています。
 
-Currently, two official plugins are available:
+## 開発用サーバーの起動
+```bash
+npm install
+npm run dev
+```
+上記コマンドでローカルサーバーが起動します。ブラウザで http://localhost:5173 などの URL にアクセスすると動作を確認できます。
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## 主な Vite プラグイン
 
-## Expanding the ESLint configuration
+現在、公式から次の 2 つのプラグインが提供されています。
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) : Babel を利用した Fast Refresh 対応
+- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) : SWC を利用した Fast Refresh 対応
+
+## ESLint 設定を拡張する
+
+本番アプリケーションの開発時には、型情報を利用したルールを有効にすることをおすすめします。
 
 ```js
 export default tseslint.config({
   extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
+    // ...tseslint.configs.recommended を削除してこちらを利用
     ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
+    // さらに厳しくしたい場合はこちら
     ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
+    // コードスタイルを統一したい場合はこちらも追加
     ...tseslint.configs.stylisticTypeChecked,
   ],
   languageOptions: {
-    // other options...
+    // その他のオプション
     parserOptions: {
       project: ['./tsconfig.node.json', './tsconfig.app.json'],
       tsconfigRootDir: import.meta.dirname,
@@ -31,7 +40,7 @@ export default tseslint.config({
 })
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+React 特有のルールを追加する場合は、以下のプラグインを導入できます。
 
 ```js
 // eslint.config.js
@@ -40,13 +49,13 @@ import reactDom from 'eslint-plugin-react-dom'
 
 export default tseslint.config({
   plugins: {
-    // Add the react-x and react-dom plugins
+    // react-x と react-dom プラグインを追加
     'react-x': reactX,
     'react-dom': reactDom,
   },
   rules: {
-    // other rules...
-    // Enable its recommended typescript rules
+    // そのほかのルール...
+    // 推奨 TypeScript ルールを有効化
     ...reactX.configs['recommended-typescript'].rules,
     ...reactDom.configs.recommended.rules,
   },


### PR DESCRIPTION
## Summary
- rewrite README in Japanese for easier understanding by Japanese developers

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685b5e137d60832b990e7bf010dd49b4